### PR TITLE
Remove providing_args from signals

### DIFF
--- a/oidc_provider/signals.py
+++ b/oidc_provider/signals.py
@@ -2,5 +2,5 @@
 from django.dispatch import Signal
 
 
-user_accept_consent = Signal(providing_args=['user', 'client', 'scope'])
-user_decline_consent = Signal(providing_args=['user', 'client', 'scope'])
+user_accept_consent = Signal()
+user_decline_consent = Signal()


### PR DESCRIPTION
Signal's providing args are deprecated in django 4 and thus needs to be removed.

Refs HP-2441
